### PR TITLE
Add category screen and filtering

### DIFF
--- a/lib/screens/category_screen.dart
+++ b/lib/screens/category_screen.dart
@@ -1,0 +1,99 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
+import '../models/fiche.dart';
+import 'fiche_list_screen.dart';
+
+class Category {
+  final String title;
+  final List<String> themes;
+  const Category(this.title, this.themes);
+}
+
+class CategoryScreen extends StatefulWidget {
+  const CategoryScreen({super.key});
+
+  @override
+  State<CategoryScreen> createState() => _CategoryScreenState();
+}
+
+class _CategoryScreenState extends State<CategoryScreen> {
+  final List<Category> categories = const [
+    Category('Infractions contre les personnes', [
+      'Atteintes volontaires à la vie',
+      'Atteintes involontaires à la vie',
+      'Violences',
+      'Infractions sexuelles',
+    ]),
+    Category('Infractions contre les biens', [
+      'Vol',
+      'Extorsion',
+      'Escroquerie',
+      'Recel',
+    ]),
+    Category('Infractions contre la Nation', [
+      'Terrorisme',
+      'Trahison',
+    ]),
+  ];
+
+  late Future<Set<String>> _availableThemes;
+
+  @override
+  void initState() {
+    super.initState();
+    _availableThemes = _loadThemes();
+  }
+
+  Future<Set<String>> _loadThemes() async {
+    final data = await rootBundle.loadString('assets/data/fiches.json');
+    final List<dynamic> ficheList = json.decode(data);
+    final fiches = ficheList.map((e) => Fiche.fromJson(e)).toList();
+    return fiches.map((f) => f.theme).toSet();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Catégories')),
+      body: FutureBuilder<Set<String>>(
+        future: _availableThemes,
+        builder: (context, snapshot) {
+          final availableThemes = snapshot.data ?? <String>{};
+          return ListView.builder(
+            itemCount: categories.length,
+            itemBuilder: (context, index) {
+              final category = categories[index];
+              final filteredThemes =
+                  category.themes.where((t) => availableThemes.contains(t)).toList();
+              if (filteredThemes.isEmpty) return const SizedBox();
+              return Card(
+                margin: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+                child: ExpansionTile(
+                  title: Text(category.title),
+                  children: [
+                    for (final theme in filteredThemes)
+                      ListTile(
+                        title: Text(theme),
+                        trailing: const Icon(Icons.chevron_right_rounded),
+                        onTap: () {
+                          Navigator.of(context).push(
+                            PageRouteBuilder(
+                              pageBuilder: (_, animation, __) => FadeTransition(
+                                opacity: animation,
+                                child: FicheListScreen(filterThemes: [theme]),
+                              ),
+                            ),
+                          );
+                        },
+                      ),
+                  ],
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/fiche_list_screen.dart
+++ b/lib/screens/fiche_list_screen.dart
@@ -7,7 +7,9 @@ import 'fiche_detail_screen.dart';
 import 'package:flutter/services.dart' show rootBundle;
 
 class FicheListScreen extends StatefulWidget {
-  const FicheListScreen({Key? key}) : super(key: key);
+  final List<String>? filterThemes;
+
+  const FicheListScreen({Key? key, this.filterThemes}) : super(key: key);
 
   @override
   State<FicheListScreen> createState() => _FicheListScreenState();
@@ -15,6 +17,7 @@ class FicheListScreen extends StatefulWidget {
 
 class _FicheListScreenState extends State<FicheListScreen> {
   List<Fiche> fiches = [];
+  List<Fiche> categoryFiches = [];
   List<Fiche> filteredFiches = [];
   bool isLoading = true;
 
@@ -27,16 +30,21 @@ class _FicheListScreenState extends State<FicheListScreen> {
   Future<void> loadFiches() async {
     final String data = await rootBundle.loadString('assets/data/fiches.json');
     final List<dynamic> ficheList = json.decode(data);
+    fiches = ficheList.map((e) => Fiche.fromJson(e)).toList();
+    categoryFiches = widget.filterThemes == null || widget.filterThemes!.isEmpty
+        ? fiches
+        : fiches
+            .where((f) => widget.filterThemes!.contains(f.theme))
+            .toList();
     setState(() {
-      fiches = ficheList.map((e) => Fiche.fromJson(e)).toList();
-      filteredFiches = fiches;
+      filteredFiches = categoryFiches;
       isLoading = false;
     });
   }
 
   void onSearch(String query) {
     setState(() {
-      filteredFiches = fiches
+      filteredFiches = categoryFiches
           .where((fiche) =>
       fiche.titre.toLowerCase().contains(query.toLowerCase()) ||
           fiche.theme.toLowerCase().contains(query.toLowerCase()) ||

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'fiche_list_screen.dart';
+import 'category_screen.dart';
 import 'favorites_screen.dart';
 import 'cadre_list_screen.dart';
 
@@ -38,7 +38,7 @@ class HomeScreen extends StatelessWidget {
                     PageRouteBuilder(
                       pageBuilder: (_, animation, __) => FadeTransition(
                         opacity: animation,
-                        child: const FicheListScreen(),
+                        child: const CategoryScreen(),
                       ),
                     ),
                   );


### PR DESCRIPTION
## Summary
- create `CategoryScreen` listing major infraction categories
- filter `FicheListScreen` by selected themes
- open `CategoryScreen` from home instead of the fiche list

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bdfda8760832da5309179dcf14947