### PR TITLE
Ajout d'un loader JSON sans commentaires

### DIFF
--- a/lib/screens/category_screen.dart
+++ b/lib/screens/category_screen.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart' show rootBundle;
+import '../utils/json_loader.dart';
 import '../models/fiche.dart';
 import 'fiche_list_screen.dart';
 
@@ -46,7 +46,7 @@ class _CategoryScreenState extends State<CategoryScreen> {
   }
 
   Future<Set<String>> _loadThemes() async {
-    final data = await rootBundle.loadString('assets/data/fiches.json');
+    final data = await loadJsonWithComments('assets/data/fiches.json');
     final List<dynamic> ficheList = json.decode(data);
     final fiches = ficheList.map((e) => Fiche.fromJson(e)).toList();
     return fiches.map((f) => f.theme).toSet();

--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart' show rootBundle;
+import '../utils/json_loader.dart';
 import '../models/fiche.dart';
 import '../widgets/fiche_card.dart';
 import '../utils/favorites_manager.dart';
@@ -25,7 +25,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
 
   Future<void> loadFavorites() async {
     final ids = await FavoritesManager.getFavorites();
-    final data = await rootBundle.loadString('assets/data/fiches.json');
+    final data = await loadJsonWithComments('assets/data/fiches.json');
     final List<dynamic> ficheList = json.decode(data);
     final allFiches = ficheList.map((e) => Fiche.fromJson(e)).toList();
     setState(() {

--- a/lib/screens/fiche_list_screen.dart
+++ b/lib/screens/fiche_list_screen.dart
@@ -4,7 +4,7 @@ import '../models/fiche.dart';
 import '../widgets/fiche_card.dart';
 import '../widgets/search_bar.dart';
 import 'fiche_detail_screen.dart';
-import 'package:flutter/services.dart' show rootBundle;
+import '../utils/json_loader.dart';
 
 class FicheListScreen extends StatefulWidget {
   final List<String>? filterThemes;
@@ -28,7 +28,8 @@ class _FicheListScreenState extends State<FicheListScreen> {
   }
 
   Future<void> loadFiches() async {
-    final String data = await rootBundle.loadString('assets/data/fiches.json');
+    final String data =
+        await loadJsonWithComments('assets/data/fiches.json');
     final List<dynamic> ficheList = json.decode(data);
     fiches = ficheList.map((e) => Fiche.fromJson(e)).toList();
     categoryFiches = widget.filterThemes == null || widget.filterThemes!.isEmpty

--- a/lib/utils/json_loader.dart
+++ b/lib/utils/json_loader.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/services.dart' show rootBundle;
+
+/// Charge un fichier JSON contenant éventuellement des commentaires.
+/// Les commentaires de type `// ...` et `/* ... */` sont supprimés avant
+/// de renvoyer la chaîne.
+Future<String> loadJsonWithComments(String path) async {
+  final data = await rootBundle.loadString(path);
+  final withoutBlock = data.replaceAll(
+    RegExp(r'/\*.*?\*/', dotAll: true),
+    '',
+  );
+  final withoutLine = withoutBlock.replaceAll(
+    RegExp(r'^\s*//.*\$', multiLine: true),
+    '',
+  );
+  return withoutLine;
+}


### PR DESCRIPTION
## Résumé
- ajoute `loadJsonWithComments` dans `lib/utils/json_loader.dart`
- utilise ce loader dans `FicheListScreen`, `FavoritesScreen` et `CategoryScreen`

## Tests
- `flutter test` *(échoue : `flutter` manquant)*

------
https://chatgpt.com/codex/tasks/task_e_686d7162f8b0832d9a4a0a71a90babcf