### PR TITLE
Ajout d'un test JSON pour loadJsonWithComments

### DIFF
--- a/test/infractions.jsonc
+++ b/test/infractions.jsonc
@@ -1,0 +1,8 @@
+[
+  // Première infraction avec toutes les clés
+  { "type": "Vol", "definition": "Prendre la chose d'autrui" },
+  // Absence de clé definition
+  { "type": "Escroquerie" },
+  // definition explicite à null
+  { "type": "Harcèlement", "definition": null }
+]


### PR DESCRIPTION
## Résumé
- remplacer le widget test initial par un test unitaire
- vérifier que `loadJsonWithComments` retourne un JSON parsable
- s'assurer que chaque `Infraction` est instanciée même en cas de clés absentes
- ajouter un fichier JSONC d'exemple pour les tests

## Tests
- `dart test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_686d716e0598832d941f7b6c4be719f9