### PR TITLE
Ajout d'un test pour fiches.json

### DIFF
--- a/lib/models/infraction.dart
+++ b/lib/models/infraction.dart
@@ -82,6 +82,9 @@ class Infraction {
   final List<CirconstanceAggravanteInfraction>? circonstancesAggravantes;
   final List<JurisprudenceRef>? jurisprudence;
   final dynamic particularites;
+  final String? responsabilitePersonnesMorales;
+  final String? territorialite;
+  final String? causesExemptionDiminutionPeine;
 
   Infraction({
     required this.id,
@@ -95,6 +98,9 @@ class Infraction {
     this.circonstancesAggravantes,
     this.jurisprudence,
     this.particularites,
+    this.responsabilitePersonnesMorales,
+    this.territorialite,
+    this.causesExemptionDiminutionPeine,
   });
 
   factory Infraction.fromJson(Map<String, dynamic> json, {required String id}) => Infraction(
@@ -113,6 +119,9 @@ class Infraction {
             .toList(),
         jurisprudence: (json['jurisprudence'] as List?)?.map((e) => JurisprudenceRef.fromJson(e)).toList(),
         particularites: json['particularites'],
+        responsabilitePersonnesMorales: json['responsabilite_personnes_morales'],
+        territorialite: json['territorialite'],
+        causesExemptionDiminutionPeine: json['causes_exemption_diminution_peine'],
       );
 }
 

--- a/test/fiches_load_test.dart
+++ b/test/fiches_load_test.dart
@@ -1,0 +1,27 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:droitpenalspecial/models/infraction.dart';
+import 'package:droitpenalspecial/utils/json_loader.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('chargement de fiches.json et instanciation', () async {
+    final jsonStr = await loadJsonWithComments('assets/data/fiches.json');
+    final List<dynamic> data = jsonDecode(jsonStr);
+
+    expect(() => data.map(FamilleInfractions.fromJson).toList(), returnsNormally);
+  });
+
+  test('presence des nouveaux champs', () async {
+    final jsonStr = await loadJsonWithComments('assets/data/fiches.json');
+    final List<dynamic> data = jsonDecode(jsonStr);
+    final familles = data.map(FamilleInfractions.fromJson).toList();
+    final infractions = familles.expand((f) => f.infractions);
+
+    expect(infractions.any((i) => i.responsabilitePersonnesMorales != null), isTrue);
+    expect(infractions.any((i) => i.territorialite != null), isTrue);
+    expect(infractions.any((i) => i.causesExemptionDiminutionPeine != null), isTrue);
+  });
+}


### PR DESCRIPTION
## Résumé
- prise en charge de nouveaux champs dans `Infraction`
- ajout d'un test qui charge `assets/data/fiches.json` avec `loadJsonWithComments`
- vérification de l'absence d'exception lors de la création des modèles
- test de présence des champs `responsabilitePersonnesMorales`, `territorialite` et `causesExemptionDiminutionPeine`

## Tests
- `flutter test` *(échoue : commande flutter introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_686d7dc42a9c832dbeecb5de2a38b34d